### PR TITLE
Backported cp fix from v0.11.0

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -450,6 +450,7 @@ public class RNFetchBlobFS {
         path = normalizePath(path);
         InputStream in = null;
         OutputStream out = null;
+        String message = "";
 
         try {
 
@@ -470,7 +471,7 @@ public class RNFetchBlobFS {
             }
 
         } catch (Exception err) {
-            callback.invoke(err.getLocalizedMessage());
+            message += err.getLocalizedMessage();
         } finally {
             try {
                 if (in != null) {
@@ -479,10 +480,15 @@ public class RNFetchBlobFS {
                 if (out != null) {
                     out.close();
                 }
-                callback.invoke();
             } catch (Exception e) {
-                callback.invoke(e.getLocalizedMessage());
+                message += e.getLocalizedMessage();
             }
+        }
+
+        if (message != "") {
+            callback.invoke(message);
+        } else {
+            callback.invoke();
         }
     }
 


### PR DESCRIPTION
This patch fixes the multiple callback invocations during a failed file
copy that crashes react-native.
